### PR TITLE
enable clean up instances from prev failed runs by node versions

### DIFF
--- a/.kokoro/cleanup.sh
+++ b/.kokoro/cleanup.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -xeo pipefail
+set -eo pipefail
 
 export NPM_CONFIG_PREFIX=/home/node/.npm-global
 

--- a/.kokoro/docs.sh
+++ b/.kokoro/docs.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -xeo pipefail
+set -eo pipefail
 
 export NPM_CONFIG_PREFIX=/home/node/.npm-global
 

--- a/.kokoro/lint.sh
+++ b/.kokoro/lint.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -xeo pipefail
+set -eo pipefail
 
 export NPM_CONFIG_PREFIX=/home/node/.npm-global
 

--- a/.kokoro/samples-test.sh
+++ b/.kokoro/samples-test.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -xeo pipefail
+set -eo pipefail
 
 export NPM_CONFIG_PREFIX=/home/node/.npm-global
 

--- a/.kokoro/system-test.sh
+++ b/.kokoro/system-test.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -xeo pipefail
+set -eo pipefail
 
 export NPM_CONFIG_PREFIX=/home/node/.npm-global
 

--- a/.kokoro/test.sh
+++ b/.kokoro/test.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -xeo pipefail
+set -eo pipefail
 
 export NPM_CONFIG_PREFIX=/home/node/.npm-global
 

--- a/.kokoro/trampoline.sh
+++ b/.kokoro/trampoline.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -xeo pipefail
+set -eo pipefail
 
 # Always run the cleanup script, regardless of the success of bouncing into
 # the container.

--- a/system-test/spanner.ts
+++ b/system-test/spanner.ts
@@ -4358,12 +4358,7 @@ function shortUUID() {
 }
 
 function generateName(resourceType) {
-  return (
-    PREFIX +
-    resourceType +
-    '-' +
-    shortUUID()
-  );
+  return PREFIX + resourceType + '-' + shortUUID();
 }
 
 function onPromiseOperationComplete(data) {

--- a/system-test/spanner.ts
+++ b/system-test/spanner.ts
@@ -1233,10 +1233,10 @@ describe('Spanner', () => {
     });
 
     it('should insert and query multiple rows', done => {
-      const id1 = generateName('id');
+      const id1 = generateName('id1');
       const name1 = generateName('name');
 
-      const id2 = generateName('id');
+      const id2 = generateName('id2');
       const name2 = generateName('name');
 
       table.insert(
@@ -1346,7 +1346,7 @@ describe('Spanner', () => {
       });
     });
 
-    describe('insert & query', () => {
+    describe.skip('insert & query', () => {
       const ID = generateName('id');
       const NAME = generateName('name');
       const FLOAT = 8.2;
@@ -2750,7 +2750,7 @@ describe('Spanner', () => {
       });
     });
 
-    describe('upsert', () => {
+    describe.skip('upsert', () => {
       const ROW = {
         SingerId: generateName('id'),
         Name: generateName('name'),
@@ -2802,7 +2802,7 @@ describe('Spanner', () => {
       });
     });
 
-    describe('read', () => {
+    describe.skip('read', () => {
       const table = database.table('ReadTestTable');
 
       const ALL_COLUMNS = ['Key', 'StringValue'];
@@ -3193,10 +3193,10 @@ describe('Spanner', () => {
     });
 
     it('should insert and query multiple rows', done => {
-      const id1 = generateName('id');
+      const id1 = generateName('id1');
       const name1 = generateName('name');
 
-      const id2 = generateName('id');
+      const id2 = generateName('id2');
       const name2 = generateName('name');
 
       table.insert(

--- a/system-test/spanner.ts
+++ b/system-test/spanner.ts
@@ -24,10 +24,7 @@ import * as uuid from 'uuid';
 import {Spanner} from '../src';
 
 const PREFIX = 'gcloud-tests-';
-const RUN_ID = uuid
-  .v1()
-  .split('-')
-  .shift(); // get a short uuid
+const RUN_ID = shortUUID();
 const LABEL = `gcloud-tests-${RUN_ID}`;
 const spanner = new Spanner({projectId: process.env.GCLOUD_PROJECT});
 
@@ -4353,15 +4350,19 @@ describe('Spanner', () => {
   });
 });
 
+function shortUUID() {
+  return uuid
+    .v4()
+    .split('-')
+    .shift();
+}
+
 function generateName(resourceType) {
   return (
     PREFIX +
     resourceType +
     '-' +
-    uuid
-      .v1()
-      .split('-')
-      .shift()
+    shortUUID()
   );
 }
 

--- a/system-test/spanner.ts
+++ b/system-test/spanner.ts
@@ -1346,7 +1346,7 @@ describe('Spanner', () => {
       });
     });
 
-    describe.skip('insert & query', () => {
+    describe('insert & query', () => {
       const ID = generateName('id');
       const NAME = generateName('name');
       const FLOAT = 8.2;
@@ -2750,7 +2750,7 @@ describe('Spanner', () => {
       });
     });
 
-    describe.skip('upsert', () => {
+    describe('upsert', () => {
       const ROW = {
         SingerId: generateName('id'),
         Name: generateName('name'),
@@ -2802,7 +2802,7 @@ describe('Spanner', () => {
       });
     });
 
-    describe.skip('read', () => {
+    describe('read', () => {
       const table = database.table('ReadTestTable');
 
       const ALL_COLUMNS = ['Key', 'StringValue'];


### PR DESCRIPTION
Towards issue 535

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
